### PR TITLE
OT247 62 | Agregar Slides a endpoint público

### DIFF
--- a/migrations/20220716021559-create-slide.js
+++ b/migrations/20220716021559-create-slide.js
@@ -34,6 +34,10 @@ module.exports = {
         allowNull: false,
         type: Sequelize.DATE,
       },
+      deletedAt: {
+        type: Sequelize.DATE,
+        allowNull: true,
+      },
     });
   },
   down: async (queryInterface, Sequelize) => {

--- a/models/organization.js
+++ b/models/organization.js
@@ -4,7 +4,11 @@ const {
 
 module.exports = (sequelize, DataTypes) => {
   class Organization extends Model {
-    static associate(models) {}
+    static associate(models) {
+      Organization.hasMany(models.Slide, {
+        foreignKey: 'organizationId',
+      });
+    }
   }
   Organization.init({
     id: {

--- a/models/slide.js
+++ b/models/slide.js
@@ -10,7 +10,10 @@ module.exports = (sequelize, DataTypes) => {
      * The `models/index` file will call this method automatically.
      */
     static associate(models) {
-      // define association here
+      Slide.belongsTo(models.Organization, {
+        foreignKey: 'id',
+        target_key: 'organizationId',
+      });
     }
   }
   Slide.init({

--- a/services/organization.js
+++ b/services/organization.js
@@ -1,10 +1,16 @@
 const { Organization } = require('../models');
+const { Slide } = require('../models');
 
 const getPublicOrgService = async (id) => {
   try {
     return await Organization.findOne({
       attributes: ['name', 'image', 'phone', 'address'],
       where: { id },
+      include: {
+        model: Slide,
+        attributes: ['imageUrl', 'text', 'order'],
+      },
+      order: [[Slide, 'order', 'ASC']],
     });
   } catch (err) {
     return { error: err };


### PR DESCRIPTION
https://alkemy-labs.atlassian.net/browse/OT247-62

COMO usuario
QUIERO ver Slides cuando entro a la pagina
PARA estar más informados sobre ellos

Criterios de aceptación:

- En el endpoint de datos públicos de la Organización, se deberán agregar el listado de Slides ordenados por el campo "order". (Validar si es |organizations)

- Los Slides serán los pertenecientes a la Organización, en base al campo organization_id que deberá corresponder a la Organización que se está devolviendo

Evidence: 
![Captura de pantalla 2022-08-01 140744](https://user-images.githubusercontent.com/78882685/182205308-77a5ba14-def3-4919-9b96-58564d2528de.png)

