### PR TITLE
server timeout

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,3 +1,4 @@
+const createHttpError = require('http-errors');
 const createError = require('http-errors');
 const express = require('express');
 const path = require('path');
@@ -19,6 +20,26 @@ app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
 app.use(cookieParser());
 app.use(express.static(path.join(__dirname, 'public')));
+
+const apiTimeout = 200000;
+app.use((req, res, next) => {
+  req.setTimeout(apiTimeout, () => {
+    const httpError = createHttpError(
+      408,
+      `[${req.method} ${req.url}]: Request timeout`,
+    );
+    next(httpError);
+  });
+
+  res.setTimeout(apiTimeout, () => {
+    const httpError = createHttpError(
+      503,
+      `[${req.method} ${req.url}]: Service unavailable`,
+    );
+    next(httpError);
+  });
+  next();
+});
 
 app.use('/', indexRouter);
 


### PR DESCRIPTION
 # Definir tiempo de espera en el servidor

- Tener un tiempo definido en las peticiones y evitar que un usuario espere un tiempo prolongado a que el servidor responda

### Tests:
![Captura de pantalla 2022-08-20 202215](https://user-images.githubusercontent.com/78882685/185769194-854ed32d-39d1-420e-9a80-b88b2cff832f.png)
